### PR TITLE
feat: config local mode as default drive mode

### DIFF
--- a/lib/src/commands/drive/drive_command.dart
+++ b/lib/src/commands/drive/drive_command.dart
@@ -39,7 +39,6 @@ class DriveCommand extends Command {
       ..addOption(
         ksApiKey,
         abbr: 'a',
-        mandatory: true,
         help: kCommandDriveHelpApiKey,
         valueHelp: 'XXXXX-XXX-XXXXXXX-XX',
       )
@@ -52,12 +51,16 @@ class DriveCommand extends Command {
   @override
   Future<void> run() async {
     try {
-      _logger.sessionMateOutput(message: 'Starting SweetCore...');
+      _logger.sessionMateOutput(message: kCommandDriveSweetCoreStarts);
 
       final sweetCore = await SweetCore.setup();
       await sweetCore.initialise();
 
-      _logger.sessionMateOutput(message: 'SweetCore initialised');
+      _logger.sessionMateOutput(message: kCommandDriveSweetCoreInitialised);
+
+      if (argResults![ksApiKey] == null) {
+        _logger.sessionMateOutput(message: kCommandDriveLocalModeOnly);
+      }
 
       if (argResults![ksLogSweetCoreEvents]) {
         sweetCore.logsStream.listen((event) {

--- a/lib/src/constants/message_constants.dart
+++ b/lib/src/constants/message_constants.dart
@@ -16,6 +16,13 @@ const String kCommandDriveDescription = 'Drives guest app.';
 
 const String kCommandDriveName = 'drive';
 
+const String kCommandDriveSweetCoreStarts = 'Starting SweetCore...';
+
+const String kCommandDriveSweetCoreInitialised = 'SweetCore initialised';
+
+const String kCommandDriveLocalModeOnly =
+    'Session Mate restricted to local mode only. To enable extra features 🔥 please set your API key.';
+
 const String kCommandDriveHelpDelay =
     'Sets the delay in milliseconds between each step.';
 
@@ -27,7 +34,7 @@ const String kCommandDriveHelpApiKey =
     'The API key provided when you bought your subscription. Contact dane@sessionmate.dev if you didn\'t receive one when you signed up.';
 
 const String kCommandDriveHelpAdditionalCommands =
-    'The command to attatch at the end of flutter run command. Commonly used for passing in dart-defines or flavors';
+    'The command to attatch at the end of flutter run command. Commonly used for passing in dart-defines or flavors.';
 
 const String kCommandUpdateDescription =
     'Updates session_mate_cli to latest version.';


### PR DESCRIPTION
When drive command is executed on the CLI, the application is going to be driven locally unless API Key is passed with the option.